### PR TITLE
Bump guacamole release

### DIFF
--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.5.5
+appVersion: 1.6.0
 description:
   Apache Guacamole is a clientless remote desktop gateway. It supports
   standard protocols like VNC, RDP, and SSH.
@@ -9,7 +9,9 @@ maintainers:
     name: Gavin Mogan
   - email: jens@beryju.org
     name: Jens Langhammer
+  - email: michael@alcatrash.org
+    name: Michael Trip
 name: guacamole
 sources:
   - http://guacamole.apache.org/
-version: 1.4.1
+version: 1.4.2

--- a/charts/guacamole/templates/secret.yaml
+++ b/charts/guacamole/templates/secret.yaml
@@ -8,11 +8,11 @@ type: Opaque
 data:
   GUACD_HOSTNAME: {{ printf "%s-%s" (include "guacamole.name" .) "guacd" | b64enc | quote }}
   GUACD_PORT: {{ "4822" | b64enc | quote }}
-  POSTGRES_HOSTNAME: {{ .Values.postgres.hostname | b64enc | quote }}
-  POSTGRES_PORT: {{ .Values.postgres.port | b64enc | quote }}
-  POSTGRES_DATABASE: {{ .Values.postgres.database | b64enc | quote }}
-  POSTGRES_USER: {{ .Values.postgres.user | b64enc | quote }}
-  POSTGRES_PASSWORD: {{ .Values.postgres.password | b64enc | quote }}
+  POSTGRESQL_HOSTNAME: {{ .Values.postgres.hostname | b64enc | quote }}
+  POSTGRESQL_PORT: {{ .Values.postgres.port | b64enc | quote }}
+  POSTGRESQL_DATABASE: {{ .Values.postgres.database | b64enc | quote }}
+  POSTGRESQL_USER: {{ .Values.postgres.user | b64enc | quote }}
+  POSTGRESQL_PASSWORD: {{ .Values.postgres.password | b64enc | quote }}
   WEBAPP_CONTEXT: {{ "ROOT" | b64enc | quote }}
   {{- range $key, $value := .Values.guacamole.settings }}
   {{ $key }}: {{ $value | b64enc | quote }}


### PR DESCRIPTION
This PR fixes a bug when bumping the release to 1.6.0. I had some problems with a strange error called: "postgres-port" is not a integer. I fixed it by setting the new environment variables to `POSTGRESQL_` prefix instead of `POSTGRES`. This seems to work with 1.6.0

I have also bumped the version in the Chart.yaml and i have added myself as maintainer :rofl: 

I you have any questions: let me know :+1: 